### PR TITLE
perf(logging): :zap: [NONE-1] Remove all DEBUG level logging from index

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -293,7 +293,6 @@ class TouchPortalClient extends EventEmitter {
     this.socket = new net.Socket();
     this.socket.setEncoding('utf-8');
     this.socket.connect(SOCKET_PORT, SOCKET_IP, () => {
-      parent.logIt('INFO', 'Connected to TouchPortal');
       parent.emit('connected');
       parent.pair();
     });
@@ -310,57 +309,45 @@ class TouchPortalClient extends EventEmitter {
           case 'closePlugin':
             if (message.pluginId === parent.pluginId) {
               parent.emit('Close', message);
-              parent.logIt('WARN', 'received Close Plugin message');
               parent.socket.end();
               process.exit(0);
             }
             break;
           case 'info':
-            parent.logIt('DEBUG', 'Info Message received');
             parent.emit('Info', message);
             if (message.settings) {
               parent.emit('Settings', message.settings);
             }
             break;
           case 'notificationOptionClicked':
-            parent.logIt('DEBUG', 'Notification Option Clicked');
             parent.emit('NotificationClicked', message);
             break;
           case 'settings':
-            parent.logIt('DEBUG', 'Settings Message received');
             // values is the key that is the same as how info contains settings key, for direct settings saving
             parent.emit('Settings', message.values);
             break;
           case 'listChange':
-            parent.logIt('DEBUG', 'ListChange Message received');
             parent.emit('ListChange', message);
             break;
           case 'action':
-            parent.logIt('DEBUG', 'Action Message received');
             parent.emit('Action', message, null);
             break;
           case 'broadcast':
-            parent.logIt('DEBUG', 'Broadcast Message received');
             parent.emit('Broadcast', message);
             break;
           case 'shortConnectorIdNotification':
-            parent.logIt('DEBUG', 'ShortID Connector Notification received');
             parent.emit('ConnectorShortIdNotification', message);
             break;
           case 'connectorChange':
-            parent.logIt('DEBUG', 'Connector Change received');
             parent.emit('ConnectorChange', message);
             break;
           case 'up':
-            parent.logIt('DEBUG', 'Up Hold Message received');
             parent.emit('Action', message, false);
             break;
           case 'down':
-            parent.logIt('DEBUG', 'Down Hold Message received');
             parent.emit('Action', message, true);
             break;
           default:
-            parent.logIt('DEBUG', `Unhandled type received ${message.type}`);
             parent.emit('Message', message);
         }
       });


### PR DESCRIPTION
No need to use DEBUG logging that is just more for edification during initial development, the caller can handle any logging they want

Fixes: Debug logging is too verbose #24