### PR TITLE
Allow plugin "stateful" disconnection/exit.

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -363,10 +363,12 @@ class TouchPortalClient extends EventEmitter {
     });
 
     this.socket.on('error', (err) => {
+      parent.emit('socketError', err);
       parent.logIt('ERROR', 'Socket Error', err.message);
     });
 
-    this.socket.on('close', () => {
+    this.socket.on('close', (hadError) => {
+      parent.emit('disconnected', hadError);
       parent.logIt('WARN', 'Connection closed');
       if (exitOnClose)
         process.exit(0);

--- a/src/client.js
+++ b/src/client.js
@@ -288,11 +288,14 @@ class TouchPortalClient extends EventEmitter {
   }
 
   connect(options = {}) {
-    const { pluginId, updateUrl } = options;
+    let { pluginId, updateUrl, exitOnClose } = options;
     this.pluginId = pluginId;
     const parent = this;
 
-    if (updateUrl !== undefined) {
+    if (typeof exitOnClose != 'boolean')
+      exitOnClose = true;
+
+    if (updateUrl) {
       this.updateUrl = updateUrl;
       this.checkForUpdate();
     }
@@ -317,7 +320,6 @@ class TouchPortalClient extends EventEmitter {
             if (message.pluginId === parent.pluginId) {
               parent.emit('Close', message);
               parent.socket.end();
-              process.exit(0);
             }
             break;
           case 'info':
@@ -359,13 +361,15 @@ class TouchPortalClient extends EventEmitter {
         }
       });
     });
-    this.socket.on('error', () => {
-      parent.logIt('ERROR', 'Socket Connection closed');
-      process.exit(0);
+
+    this.socket.on('error', (err) => {
+      parent.logIt('ERROR', 'Socket Error', err.message);
     });
 
     this.socket.on('close', () => {
       parent.logIt('WARN', 'Connection closed');
+      if (exitOnClose)
+        process.exit(0);
     });
   }
 

--- a/src/client.js
+++ b/src/client.js
@@ -375,6 +375,11 @@ class TouchPortalClient extends EventEmitter {
     });
   }
 
+  disconnect() {
+    if (this.socket && !this.socket.destroyed)
+      this.socket.end();
+  }
+
   logIt(...args) {
     const curTime = new Date().toISOString();
     const message = args;


### PR DESCRIPTION
* Adds 'exitOnClose' option to `connect()` method to control if client automatically calls `process.exit(0)` upon socket error/close  (default is `true`).
* Adds 'disconnected' event with `hadError <boolean>` parameter passed on from socket's 'close' event (`true` if the socket had a transmission error).
* Adds 'socketError' event with `err <Error>` parameter passed on from socket's 'error' event.
* Adds `disconnect()` method which closes any current connection with `socket.end()`.
* We don't need to `exit()` from multiple locations since socket's 'close' event is going to be fired regardless.

Just to note, if the only thing keeping the Node process active is the open socket to TP, then the plugin/program will exit anyway once the socket is closed/errors, regardless of the new 'exitOnClose' option.  The only thing this option controls is literally if `process.exit(0)` is called automatically upon disconnection (or lack of successful connection in the first place).



