### PR TITLE
Speed up TP message lines split and iteration.

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -307,8 +307,9 @@ class TouchPortalClient extends EventEmitter {
     this.socket.on('data', (data) => {
       const lines = data.toString().split('\n');
 
-      lines.forEach((line) => {
-        if (line === '') { return; }
+      for (const line of lines) {
+        if (!line)
+            break;
         const message = JSON.parse(line);
 
         // Handle internal TP Messages here, else pass to user code
@@ -357,7 +358,8 @@ class TouchPortalClient extends EventEmitter {
           default:
             parent.emit('Message', message);
         }
-      });
+      }
+
     });
     this.socket.on('error', () => {
       parent.logIt('ERROR', 'Socket Connection closed');

--- a/src/client.js
+++ b/src/client.js
@@ -305,7 +305,7 @@ class TouchPortalClient extends EventEmitter {
     });
 
     this.socket.on('data', (data) => {
-      const lines = data.toString().split(/(?:\r\n|\r|\n)/);
+      const lines = data.toString().split('\n');
 
       lines.forEach((line) => {
         if (line === '') { return; }


### PR DESCRIPTION
There's no reason to look for `\r` when splitting... it's never there, and even if it was that wouldn't interfere with JSON parsing.  As per TP API specs, messages _always_ end with a `\n`.

```
split Char  1 line  x 4,702,052 ops/sec ±0.32% (588 runs sampled)
split RegEx 1 line  x 3,325,258 ops/sec ±0.23% (592 runs sampled)
split Char  3 lines x 3,553,855 ops/sec ±0.30% (590 runs sampled)
split RegEx 3 lines x 1,045,925 ops/sec ±0.22% (593 runs sampled)
split Char  9 lines x 2,013,453 ops/sec ±0.21% (592 runs sampled)
split RegEx 9 lines x   372,140 ops/sec ±0.21% (586 runs sampled)
```

The loop type change is a much more moderate improvement, more so for blocks with fewer lines (likely because the overhead of instantiating the callback function happens only once and after that the process will be nearly identical).

```
iterate for..of 1 line  x 4,545,153 ops/sec ±0.14% (1090 runs sampled)
iterate forEach 1 line  x 4,359,194 ops/sec ±0.19% (1090 runs sampled)
iterate for..of 9 lines x 1,899,128 ops/sec ±0.18% (1090 runs sampled)
iterate forEach 9 lines x 1,888,096 ops/sec ±0.15% (1091 runs sampled)
```