### PR TITLE
Allow redirection or quelling of logging output.

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -28,7 +28,7 @@ class TouchPortalClient extends EventEmitter {
    * @constructs {TouchPortalClient}
    */
   constructor(options = {}) {
-    //@ts-expect-error   TS doesn't seem to have proper typing for Node's EventEmitter c'tor which accepts an options object
+    //@ts-ignore   TS doesn't seem to have proper typing for Node's EventEmitter c'tor which accepts an options object
     super(options);
     this.touchPortal = null;
     this.pluginId = options?.pluginId;

--- a/src/client.js
+++ b/src/client.js
@@ -11,12 +11,27 @@ const SOCKET_PORT = 12136;
 const CONNECTOR_PREFIX = 'pc';
 
 class TouchPortalClient extends EventEmitter {
-  constructor() {
-    super();
+  /**
+   * Creates a new `TouchPortalClient` instance.
+   * @param {Object} [options] Optional runtime settings for TouchPortalClient and EventEmitter.
+   * @param {(function(string, string | any, ...any?):void) | null} [options.logCallback]
+   *  - Log callback function called by `logIt()` method instead of `console.log()`, or `null` to disable logging.
+   *
+   *  Arguments passed to callback:
+   *     * `level: string` - Logging level string, eg. "DEBUG"/"INFO"/"WARN"/"ERROR".
+   *     * `message?: string | any` - The log message or some other value type to log, possibly `undefined`.
+   *     * `...args: any[]` - Possible further argument(s) passed to the callback if logIt() was called with > 2 arguments.
+   * @constructs {TouchPortalClient}
+   */
+  constructor(options = {}) {
     this.touchPortal = null;
     this.pluginId = null;
     this.socket = null;
     this.customStates = {};
+    if (options && (options.logCallback === null || typeof options.logCallback == 'function'))
+        this.logCallback = options.logCallback;
+    else
+        this.logCallback = undefined;
   }
 
   createState(id, desc, defaultValue, parentGroup) {
@@ -383,10 +398,16 @@ class TouchPortalClient extends EventEmitter {
   }
 
   logIt(...args) {
-    const curTime = new Date().toISOString();
-    const message = args;
-    const type = message.shift();
-    console.log(curTime, ':', this.pluginId, `:${type}:`, ...message);
+    // must be a strict compare
+    if (this.logCallback === undefined) {
+      const curTime = new Date().toISOString();
+      const message = args;
+      const type = message.shift();
+      console.log(curTime, ':', this.pluginId, `:${type}:`, ...message);
+    }
+    else if (this.logCallback) {
+      this.logCallback(args.shift(), args.shift(), ...args);
+    }
   }
 }
 

--- a/src/client.js
+++ b/src/client.js
@@ -314,8 +314,8 @@ class TouchPortalClient extends EventEmitter {
     if (pluginId)
       this.pluginId = pluginId;
     if (!this.pluginId) {
-      this.logIt('ERROR', "Plugin ID is missing or empty.");
-      // throw error?
+      this.logIt('ERROR', "connect: Plugin ID is missing or empty.");
+      throw new Error('connect: Plugin ID is missing or empty.');
     }
 
     if (typeof exitOnClose != 'boolean')

--- a/src/client.js
+++ b/src/client.js
@@ -14,6 +14,7 @@ class TouchPortalClient extends EventEmitter {
   /**
    * Creates a new `TouchPortalClient` instance.
    * @param {Object} [options] Optional runtime settings for TouchPortalClient and EventEmitter.
+   * @param {boolean} [options.captureRejections] - Passed through to EventEmitter
    * @param {(function(string, string | any, ...any?):void) | null} [options.logCallback]
    *  - Log callback function called by `logIt()` method instead of `console.log()`, or `null` to disable logging.
    *
@@ -24,6 +25,8 @@ class TouchPortalClient extends EventEmitter {
    * @constructs {TouchPortalClient}
    */
   constructor(options = {}) {
+    //@ts-expect-error   TS doesn't seem to have proper typing for Node's EventEmitter c'tor which accepts an options object
+    super(options);
     this.touchPortal = null;
     this.pluginId = null;
     this.socket = null;

--- a/src/client.js
+++ b/src/client.js
@@ -413,10 +413,7 @@ class TouchPortalClient extends EventEmitter {
   logIt(...args) {
     // must be a strict compare
     if (this.logCallback === undefined) {
-      const curTime = new Date().toISOString();
-      const message = args;
-      const type = message.shift();
-      console.log(curTime, ':', this.pluginId, `:${type}:`, ...message);
+      console.log(`${new Date().toISOString()} : ${this.pluginId} :${args.shift()}:`, ...args);
     }
     else if (this.logCallback) {
       this.logCallback(args.shift(), args.shift(), ...args);


### PR DESCRIPTION
* Adds optional `options` object argument to Client constructor with the following properties (all also optional):
  * `logCallback: function | null` - Can be a callback function or `null` to disable logging. If `undefined` (default) then uses `console.log()` for logging, as before.
    * Arguments passed to callback:
      * `level: string` - Logging level string, eg. "DEBUG"/"INFO"/"WARN"/"ERROR".
      * `message?: string | any` - The log message or some other value type to log, possibly `undefined`.
      * `...args: any[]` - Possible further argument(s) passed to the callback if logIt() was called with > 2 arguments.
  * `pluginId: string` - Can be specified here instead of in `connect()` because one may use `logIt()` before `connect()`.  ID specified in `connect()` options (if any) overrides the ones set in c'tor.
  * `captureRejections: boolean` - Passed through to [EventEmitter](https://nodejs.org/docs/latest/api/events.html#class-eventemitter) c'tor.
* Throws exception and logs an error if `pluginId` is empty when `connect()` is invoked. ~~Should this throw?~~
* Skip some unnecessary intermediate reference var creation when logging a message.
