### PR TITLE
Update 'eslint-plugin-import' dependency to silence cascading JSON version vulnerability warnings.

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "devDependencies": {
     "eslint": "^8.21.0",
     "eslint-config-airbnb-base": "^15.0.0",
-    "eslint-plugin-import": "^2.26.0",
+    "eslint-plugin-import": "^2.28.1",
     "typescript": "^4.7.4"
   }
 }


### PR DESCRIPTION
json package v1.0.1 which has an end-of-world-high-level-security-issue 😛  is a dependency of 'eslint-plugin-import' so this fixes the warnings from npm and the GitHub bot.  By "cascading" I mean every other package which depends on this one.

Do we even need this 'eslint-plugin-import' package?  Using `tsc` already validates everything anyway, and VSCode, for example, flags invalid imports already w/out any extra package deps.