### PR TITLE
updateCheck changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Touch Portal Node API - Change Log
 
+## v4.0.0
+  ### New Features: 
+  - Developers may now initiate a plugin update check at any time using the `checkForUpdate` function from TPClient
+    - Allows option to include pre-releases from github allowing users to decide to download alpha/beta versions ([#44])
+
+  ### Changes
+   - `TPClient.Connect` no longer accepts `updateUrl` to initate a github update check upon plugin connect.
+   - `TPClient.checkForUpdate` now takes the args `githubUser`, `githubRepo` and `includePrerelease`
+    - Example: `TPClient.checkForUpdate("spdermn02", "TouchPortal_Discord_Plugin", includePrerelease)`
+
+[#44]: https://github.com/spdermn02/touchportal-node-api/pull/44
+
 ## v3.3.0
   ### New Features:
   - Allow plugin "stateful" disconnection/exit ([#36]):
@@ -37,7 +49,6 @@
 [#39]: https://github.com/spdermn02/touchportal-node-api/pull/39
 [#40]: https://github.com/spdermn02/touchportal-node-api/pull/40
 [#41]: https://github.com/spdermn02/touchportal-node-api/pull/41
-
 ---
 ## v3.2.1 - ESLint implementation and Typescript support
  ### Updates

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,8 @@
     - Allows option to include pre-releases from github allowing users to decide to download alpha/beta versions ([#44])
 
   ### Changes
-   - `TPClient.Connect` no longer accepts `updateUrl` to initate a github update check upon plugin connect.
-   - `TPClient.checkForUpdate` now takes the args `githubUser`, `githubRepo` and `includePrerelease`
+  - `TPClient.Connect` no longer accepts `updateUrl` to initate a github update check upon plugin connect.
+  - `TPClient.checkForUpdate` now takes the args `githubUser`, `githubRepo` and `includePrerelease`
     - Example: `TPClient.checkForUpdate("spdermn02", "TouchPortal_Discord_Plugin", includePrerelease)`
 
 [#44]: https://github.com/spdermn02/touchportal-node-api/pull/44

--- a/src/client.js
+++ b/src/client.js
@@ -269,9 +269,9 @@ class TouchPortalClient extends EventEmitter {
     this.send(pairMsg);
   }
 
-  checkForUpdate() {
+  checkForUpdate(githubUser, githubRepo, includePrerelease) {
     const parent = this;
-    const updateUrl = `https://api.github.com/repos/${parent.githubUser}/${parent.githubRepo}/releases`;
+    const updateUrl = `https://api.github.com/repos/${githubUser}/${githubRepo}/releases`;
     http.get(updateUrl, {headers: {'User-Agent': this.pluginId }
         }, (res) => {
         const { statusCode } = res;
@@ -295,7 +295,7 @@ class TouchPortalClient extends EventEmitter {
                 const jsonData = JSON.parse(updateData);
                 for (const release of jsonData) {
                   const releaseVersion = release.tag_name.replace('v', '');      
-                  if (this.includePrerelease || !release.prerelease) {
+                  if (includePrerelease || !release.prerelease) {
                       if (compareVersions(releaseVersion, pluginVersion) > 0) {
                           parent.emit('Update', pluginVersion, releaseVersion);
                           return;
@@ -315,7 +315,7 @@ class TouchPortalClient extends EventEmitter {
   }
 
   connect(options = {}) {
-    let { pluginId, updateCheck, exitOnClose } = options;
+    let { pluginId, exitOnClose } = options;
 
     if (pluginId)
       this.pluginId = pluginId;
@@ -326,14 +326,6 @@ class TouchPortalClient extends EventEmitter {
 
     if (typeof exitOnClose != 'boolean')
       exitOnClose = true;
-
-    if (updateCheck) {
-      this.githubRepo = updateCheck.githubRepo;
-      this.githubUser = updateCheck.githubUser;
-      this.includePrerelease = updateCheck.includePrerelease
-      this.checkForUpdate();
-    }
-
     const parent = this;
 
     this.socket = new net.Socket();

--- a/src/client.js
+++ b/src/client.js
@@ -1,6 +1,6 @@
 const EventEmitter = require('events');
 const net = require('net');
-const https = require('https');
+const http = require('https');
 const compareVersions = require('compare-versions');
 const { requireFromAppRoot } = require('require-from-app-root');
 
@@ -272,7 +272,7 @@ class TouchPortalClient extends EventEmitter {
   checkForUpdate() {
     const parent = this;
     const updateUrl = `https://api.github.com/repos/${parent.githubUser}/${parent.githubRepo}/releases`;
-    https.get(updateUrl, {headers: {'User-Agent': this.pluginId }
+    http.get(updateUrl, {headers: {'User-Agent': this.pluginId }
         }, (res) => {
         const { statusCode } = res;
         // Any 2xx status code signals a successful response but


### PR DESCRIPTION
## client.js
- updateCheck() now uses the github API to check for possible updates, includes option for preReleases - no longer requires to be sent package.json url.

if includePrerelease is true then it will include any pre-releases in the update. this can be useful for plugin developers to allow user to have access to the newest version of plugin no matter what if they wish.
 ```